### PR TITLE
Add stackitem container style and handle orientation

### DIFF
--- a/lib/ModalStack.js
+++ b/lib/ModalStack.js
@@ -22,8 +22,7 @@ const styles = StyleSheet.create({
     zIndex: 0,
   },
   backdrop: {
-    width: vw(100),
-    height: vh(100),
+    ...StyleSheet.absoluteFill,
     backgroundColor: 'black',
   },
 })

--- a/lib/StackItem.js
+++ b/lib/StackItem.js
@@ -172,7 +172,7 @@ class StackItem extends Component<Props> {
 
   render() {
     const { position, stack, stackItem, zIndex } = this.props
-    const { transitionOptions, stackItemContainerStyle = {} } = getStackItemOptions(stackItem, stack)
+    const { transitionOptions, stackItemContainerStyle } = getStackItemOptions(stackItem, stack)
 
     return (
       <Animated.View

--- a/lib/StackItem.js
+++ b/lib/StackItem.js
@@ -172,12 +172,12 @@ class StackItem extends Component<Props> {
 
   render() {
     const { position, stack, stackItem, zIndex } = this.props
-    const { transitionOptions } = getStackItemOptions(stackItem, stack)
+    const { transitionOptions, stackItemContainerStyle = {} } = getStackItemOptions(stackItem, stack)
 
     return (
       <Animated.View
         pointerEvents="box-none"
-        style={[styles.container, { zIndex }, this._getPosition(stackItem)]}
+        style={[styles.container, stackItemContainerStyle, { zIndex }, this._getPosition(stackItem)]}
       >
         {this._getAnimatedComponent(
           transitionOptions && transitionOptions(this.animatedValue)

--- a/utils/getStackItemOptions.js
+++ b/utils/getStackItemOptions.js
@@ -20,6 +20,9 @@ export default function(stackItem: StackItem, stack: Stack<Set<StackItem>>) {
       stackItem?.component.modalOptions?.shouldAnimateOut ??
       stackItem?.options?.shouldAnimateOut ??
       stack.defaultOptions.shouldAnimateOut,
+    stackItemContainerStyle: stackItem?.component.stackItemContainerStyle ||
+      stackItem.options?.stackItemContainerStyle ||
+      stack.defaultOptions.stackItemContainerStyle,
     transitionOptions:
       stackItem?.component.modalOptions?.transitionOptions ||
       stackItem?.options?.transitionOptions ||

--- a/utils/getStackItemOptions.js
+++ b/utils/getStackItemOptions.js
@@ -22,7 +22,7 @@ export default function(stackItem: StackItem, stack: Stack<Set<StackItem>>) {
       stack.defaultOptions.shouldAnimateOut,
     stackItemContainerStyle: stackItem?.component.stackItemContainerStyle ||
       stackItem.options?.stackItemContainerStyle ||
-      stack.defaultOptions.stackItemContainerStyle,
+      stack.defaultOptions.stackItemContainerStyle || {},
     transitionOptions:
       stackItem?.component.modalOptions?.transitionOptions ||
       stackItem?.options?.transitionOptions ||


### PR DESCRIPTION
This PR allows users to pass a container style to StackItems and it also removes the fixed height and width from a backdrop. This is because when I changed orientation the backdrop was still fixed to the original size.