### PR TITLE
Fix typechecking of wrapped components

### DIFF
--- a/lib/withModal.tsx
+++ b/lib/withModal.tsx
@@ -22,7 +22,7 @@ const withModal = <P extends ModalfyParams, Props extends object>(
   const displayName = Component.displayName || Component.name
 
   class WithModalComponent extends React.Component<
-    Omit<Props, keyof ModalProp<P, Props>>
+    Omit<Props, keyof ModalProp<P, {}>>
   > {
     static displayName = `withModal(${displayName})`
     static readonly WrappedComponent = Component

--- a/lib/withModal.tsx
+++ b/lib/withModal.tsx
@@ -17,7 +17,7 @@ import { invariant } from '../utils'
  * @see https://colorfy-software.gitbook.io/react-native-modalfy/api/withmodal
  */
 const withModal = <P extends ModalfyParams, Props extends object>(
-  Component: React.ComponentClass<ModalProp<P, Props>>,
+  Component: React.ComponentClass<Props>,
 ) => {
   const displayName = Component.displayName || Component.name
 
@@ -36,7 +36,6 @@ const withModal = <P extends ModalfyParams, Props extends object>(
               `You should not use ${displayName} outside a <ModalProvider>`,
             )
             return (
-              // @ts-ignore
               <Component
                 {...(this.props as Props)}
                 modal={{
@@ -54,7 +53,6 @@ const withModal = <P extends ModalfyParams, Props extends object>(
     }
   }
 
-  // @ts-ignore
   return hoistStatics(WithModalComponent, Component)
 }
 


### PR DESCRIPTION
Currently, components wrapped with `withModal` cannot be type checked properly because the declaration for the WithModalComponent class incorrectly omits all Props.  Additionally the incoming component class is mistyped as already containing the modal props.  

With these two minor fixes, wrapped components can be successfully type checked and the `@ts-ignore` overrides can be removed