### PR TITLE
ModalStateListener does not work on strict type checking of Typescript

### DIFF
--- a/lib/ModalState.ts
+++ b/lib/ModalState.ts
@@ -53,7 +53,7 @@ const createModalState = (): ModalStateType<any> => {
         }
       } catch (error) {
         subscriber.error = true
-        subscriber.listener(null, error)
+        subscriber.listener(null, error as Error)
       }
     }
 


### PR DESCRIPTION
Error:
<img width="819" alt="Screenshot 2021-10-08 at 13 29 14" src="https://user-images.githubusercontent.com/1559784/136549388-8a404519-0741-479f-8067-82fcf6920dba.png">

Resolution: Fix type passed by argument to the listener as Error.