### PR TITLE
Reorders components

### DIFF
--- a/src/lib/ModalStack.tsx
+++ b/src/lib/ModalStack.tsx
@@ -140,8 +140,8 @@ const ModalStack = <P extends ModalfyParams>(props: Props<P>) => {
         { opacity, transform: [{ translateY }] },
         Platform.OS === 'web' && stack.openedItemsSize ? styles.containerWeb : null,
       ]}>
-      {renderStack()}
       {renderBackdrop()}
+      {renderStack()}
     </Animated.View>
   )
 }


### PR DESCRIPTION
- Resolves backdrop sometimes appearing over modal when there is `react-native-reanimated` Animated component being rendered with exiting/entering animations.

Issue was previously reported [here](https://github.com/colorfy-software/react-native-modalfy/issues/66)