### PR TITLE
fix: getParam should use defaultValue only when param is undefined

### DIFF
--- a/src/lib/ModalState.ts
+++ b/src/lib/ModalState.ts
@@ -126,7 +126,7 @@ const createModalState = (): ModalStateType<any> => {
       if (item.hash === hash) stackItem = item
     })
 
-    return stackItem?.params?.[paramName] || defaultValue
+    return stackItem?.params?.[paramName] ?? defaultValue
   }
 
   const closeModal = <P>(closingElement?: Exclude<keyof P, symbol> | ModalStackItem<P>) => {


### PR DESCRIPTION
I have a modal which has an optional boolean parameter.

```
  ErrorModal: {
    dismissible?: boolean;
  };
```

When I open the modal  `openModal('ErrorModal', { dismissible: false} )` and then handle the parameters inside the Modal using `const dismissible = getParam('dismissible', true)`, it returns true even I passed the value false inside.