### PR TITLE
Fix: Untouchable screen using expo-screen-orientation

### DIFF
--- a/src/lib/ModalStack.tsx
+++ b/src/lib/ModalStack.tsx
@@ -127,7 +127,7 @@ const ModalStack = <P extends ModalfyParams>(props: Props<P>) => {
     )
   }
 
-  return (
+  return !stack.openedItemsSize ? null : (
     <Animated.View
       style={[
         styles.container,


### PR DESCRIPTION
Hi guys,

I really love this package and want to use it in my projects, but having an issue recently. I came across a situation when using it with [expo-screen-orientation](https://www.npmjs.com/package/expo-screen-orientation) package

Example to reproduce: [https://snack.expo.io/@git/github.com/vsnaichuk/react-native-modalfy-example](https://snack.expo.dev/@git/github.com/vsnaichuk/react-native-modalfy-example) 
If you change phone orientation to landscape, open and close the modal then change the orientation back to portrait, and press on the bottom part you will see that it isn't touchable. 

Test devices: Apple iPhone 7, Xiaomi Poco X3