### PR TITLE
Improved TypeScript support

### DIFF
--- a/example/src/components/HooksButton.tsx
+++ b/example/src/components/HooksButton.tsx
@@ -12,7 +12,10 @@ interface Props {
 
 const HooksButton = ({ color, title, modalName: name }: Props) => {
   const { width } = useWindowDimensions()
-  const { openModal } = useModal<ModalStackParamsList>()
+  // You can use it without explicit type, if you added it to declaration file 👇
+  const { openModal } = useModal()
+  // const { openModal } = useModal<ModalStackParamsList>()
+
   const onPress = () => {
     // Type checking at work 👇
     openModal(name, { name, color, origin: 'Hooks' })

--- a/example/src/components/IntroButton.tsx
+++ b/example/src/components/IntroButton.tsx
@@ -5,7 +5,10 @@ import { TouchableOpacity, StyleSheet, Text } from 'react-native'
 import { ModalStackParamsList } from '../App'
 
 const IntroButton = () => {
+  // You can use it without explicit type, if you added it to declaration file 👇
+  // const { openModal } = useModal()
   const { openModal } = useModal<ModalStackParamsList>()
+
   const onPress = () => openModal('IntroModal')
   return (
     <TouchableOpacity style={styles.button} onPress={onPress}>

--- a/example/src/components/PlainJS.ts
+++ b/example/src/components/PlainJS.ts
@@ -2,9 +2,11 @@ import { modalfy } from 'react-native-modalfy'
 
 import { ModalStackParamsList, ModalName } from '../App'
 
-const { openModal } = modalfy<ModalStackParamsList>()
+// You can use it without explicit type, if you added it to declaration file 👇
+const { openModal } = modalfy()
+// const { openModal } = modalfy<ModalStackParamsList>()
 
-export default function (name: ModalName, color: ModalStackParamsList[ModalName]['color']) {
+export default function <N extends ModalName>(name: N, color: ModalStackParamsList[N]['color']) {
   // Type checking at work 👇
   openModal(name, { name, color, origin: 'Plain JS' })
 }

--- a/example/src/react-native-modalfy.d.ts
+++ b/example/src/react-native-modalfy.d.ts
@@ -1,0 +1,8 @@
+import 'react-native-modalfy'
+import { ModalStackParamsList } from './App'
+
+// Add a such declaration file to make types work out of the box 👇
+declare module 'react-native-modalfy' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface ModalfyCustomParams extends ModalStackParamsList {}
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,12 @@ import type { Animated, ViewStyle } from 'react-native'
  *   ========================                ========================
  */
 
-export type ModalfyParams = { [key: string]: any }
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ModalfyCustomParams {}
+
+export type ModalfyParams = ModalfyCustomParams[keyof ModalfyCustomParams] extends never
+  ? { [key: string]: any }
+  : ModalfyCustomParams
 
 export type ModalTransitionValue = Animated.AnimatedInterpolation | string | number | undefined | null
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,9 +11,13 @@ import type { Animated, ViewStyle } from 'react-native'
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ModalfyCustomParams {}
 
-export type ModalfyParams = ModalfyCustomParams[keyof ModalfyCustomParams] extends never
+type ModalfyExtendedParams = ModalfyCustomParams[keyof ModalfyCustomParams] extends never
   ? { [key: string]: any }
   : ModalfyCustomParams
+
+// It should be declared as interface to prevent typescript type replacement
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ModalfyParams extends ModalfyExtendedParams {}
 
 export type ModalTransitionValue = Animated.AnimatedInterpolation | string | number | undefined | null
 


### PR DESCRIPTION
Added the ability to extend the default `ModalfyParams` with a custom declaration for better DX. 
It doesn't make any breaking changes and should work as before if `ModalfyCustomParams` interface is not overwritten.

Example:

1. Declare your own ModalStackParams type:
```ts
// modal.types.ts
export type ModalStackParams = {
  dialog: { title: string };
};
```

2. In the file `react-native-modalfy.d.ts` (or in the any other place when the `createModalStack` is called), add:
```ts
import 'react-native-modalfy';
import type { ModalStackParams } '/path/to/modal.types';

declare module 'react-native-modalfy' {
  interface ModalfyCustomParams extends ModalStackParams {}
}
```

3. Get full support of types out of the box:
```diff
const MyComponent = () => {
  // no need to manually pass declared ModalStackParams 👇
-  const { openModal } = useModal<ModalStackParams>();
+  const { openModal } = useModal();

  const openDialog = () => {
    // types still work well here 👇
    openModal('dialog', { title: 'Title' });
  };
  // ...
}
```