### PR TITLE
Update types.ts Refactor the openModal method type definition

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -129,7 +129,7 @@ export interface ModalContextProvider<
     paramName: N,
     defaultValue?: D,
   ) => D extends P[M][N] ? P[M][N] : undefined
-  openModal: <N extends M>(modalName: N, params?: P[N], callback?: () => void) => void
+  openModal: <N extends M>(modalName: N, params: P[N], callback?: () => void) => void
   stack: ModalStack<P>
 }
 


### PR DESCRIPTION
Ensure that params are required, so the function cannot be called without them as suggested in this issue  #135 