### PR TITLE
fix: remove "useInsertionEffect must not schedule updates" warning when closing a modal

### DIFF
--- a/src/lib/StackItem.tsx
+++ b/src/lib/StackItem.tsx
@@ -6,7 +6,7 @@ import {
   FlingGestureHandlerEventPayload,
 } from 'react-native-gesture-handler'
 import { useMemo, useCallback } from 'use-memo-one'
-import React, { ReactNode, useEffect, useRef, memo } from 'react'
+import React, { ReactNode, useEffect, useLayoutEffect, useRef, memo } from 'react'
 import { Animated, StyleSheet, ViewProps, ViewStyle } from 'react-native'
 
 import type {
@@ -88,7 +88,7 @@ const StackItem = <P extends ModalfyParams>({
     position: verticalPosition,
   } = useMemo(() => getStackItemOptions(stackItem, stack), [stack, stackItem])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     let onAnimateListener: ModalOnAnimateEventCallback | undefined = undefined
 
     if (transitionOptions && typeof transitionOptions !== 'function') {
@@ -248,7 +248,6 @@ const StackItem = <P extends ModalfyParams>({
         return 'box-none'
     }
   }, [isFirstVisibleModal, pointerEventsBehavior])
-
 
   const renderAnimatedComponent = (): ReactNode => {
     const Component = stackItem.component


### PR DESCRIPTION
This change removes this warning that appears:

`Warning: useInsertionEffect must not schedule updates`

<img width="407" alt="Screenshot 2025-06-05 at 3 43 18 PM" src="https://github.com/user-attachments/assets/3a7e2aaf-02df-4156-988c-9c507bde3b2d" />

We upgraded a project to RN 0.79.2 and this warning started appearing when closing a modal. I found that if `transitionOptions` is not present the warning will not appear. When `transitionOptions` is present on `createModalStack` this warning will appear. 

It's possible that this started showing up in RN 0.78 when they made the change to react 19.

Something must have changed internally in react 19 and/or react native.