### PR TITLE
fix: missing dependency to reset stack options

### DIFF
--- a/src/lib/ModalStack.tsx
+++ b/src/lib/ModalStack.tsx
@@ -86,7 +86,7 @@ const ModalStack = <P extends ModalfyParams>(props: Props<P>) => {
     queueMacroTask(() => {
       setModalStackOptions(getStackItemOptions(Array.from(stack.openedItems).pop(), stack))
     })
-  }, [])
+  }, [stack])
 
   const renderStackItem = (stackItem: ModalStackItem<P>, index: number) => {
     const position = stack.openedItems.size - index


### PR DESCRIPTION
It seems that after rewriting of this [file](https://github.com/colorfy-software/react-native-modalfy/commit/087a441cee135c9e1ac71e23b596930f2d731447#diff-d174846a9706fb663c95387b235a7425081f2062d5646598426464c9afb52131) `stack` dependency was missed in `useCallback resetModalStackOptions` function. 

Because of this different modals open with the same options even they have different ones in `modalStackConfig`.