### PR TITLE
Fix: Prevent backdrop press when a modal is hiding

### DIFF
--- a/src/lib/ModalStack.tsx
+++ b/src/lib/ModalStack.tsx
@@ -133,7 +133,7 @@ const ModalStack = <P extends ModalfyParams>(props: Props<P>) => {
   }
 
   const onBackdropPress = () => {
-    if (backBehavior === 'none') return
+    if (backBehavior === 'none' || stackStatus === 'hiding') return
 
     const currentItem = [...stack.openedItems].slice(-1)[0]
 


### PR DESCRIPTION
There is an issue where you're able to get a backdrop press in for a modal while it is hiding. When doing this it appears that the internal state of the rendered modal stack gets messed up.

Here is a scenario where this can be reproduced:
1. Call `openModal` for modal "A" and then call `closeModal` for it while repeatedly pressing the backdrop
2. In the `closeModal` callback of modal "A" call `openModal` for modal "B"
3. Observe that modal "B" never shows but `currentModal` is truthy and modal "B" should be showing
4. Let's say you call `openModal` for modal "C" at this point - you'll very briefly see modal "B" before modal "C" shows

This can be easier to reproduce by setting the `backdropAnimationDuration` to a higher value. That makes it easier to get a  press on the backdrop while it is hiding.

Thank you for this great library! Please let me know if this is enough to illustrate the issue.