### PR TITLE
clear modal stack synchronously to survive host unmount

### DIFF
--- a/src/lib/ModalProvider.tsx
+++ b/src/lib/ModalProvider.tsx
@@ -93,11 +93,11 @@ const ModalProvider = ({ children, stack }: Props) => {
 
   const listener: ModalStateListener<any> = (modalState, error) => {
     if (modalState) {
-      setContextValue({
-        ...contextValue,
+      setContextValue(prev => ({
+        ...prev,
         currentModal: modalState.currentModal,
         stack: modalState.stack,
-      })
+      }))
     } else console.warn('Modalfy', error)
   }
 

--- a/src/lib/ModalState.ts
+++ b/src/lib/ModalState.ts
@@ -363,7 +363,8 @@ export const modalfy = <
    * @see https://colorfy-software.gitbook.io/react-native-modalfy/api/types/modalprop#closeallmodals
    */
   closeAllModals: (callback?: () => void) => {
-    ModalState.queueClosingAction({ action: 'closeAllModals', callback })
+    ModalState.closeAllModals()
+    callback?.()
   },
   /**
    * This function closes the currently displayed modal by default.


### PR DESCRIPTION
                                                                 
  ## Summary                                                                           
                  
  Fixes a race where `modalfy().closeAllModals()` fails to clear the stack when the    
  calling component unmounts right after the call (e.g. navigating away on the same
  tick). Modals stay visible on the next screen.                                       
                  
  ## Root cause

  `modalfy().closeAllModals` routed through `queueClosingAction`, which only drains    
  after the topmost `<StackItem>`'s exit animation completes. If the `StackItem`
  unmounts before the animation finishes, the queued action is dropped and             
  `openedItems` is never cleared.

  Also fixes a latent stale-closure bug in `ModalProvider`: the subscription `listener`
   is defined outside `useEffect` but only subscribed once on mount, so
  `setContextValue({ ...contextValue, ... })` captured stale `contextValue` and        
  back-to-back state updates could silently revert to stale state.

  ## Changes

  - `src/lib/ModalState.ts` — `modalfy().closeAllModals` now calls                     
  `ModalState.closeAllModals()` directly and invokes the callback synchronously. The
  queued path still runs from `handleBackPress`, which legitimately needs the          
  - `src/lib/ModalProvider.tsx` — switch the subscription listener to a functional
  `setContextValue(prev => ...)` updater so updates always compose against the latest
  state.                                                                               
        
  ## Repro (before the fix)                                                            
                                                                                       
  1. Open one or more modals from a screen.
  2. Call `modalfy().closeAllModals()` and immediately navigate away (causing the host 
  component to unmount synchronously).                                                
  3. Navigate back — modals from step 1 are still mounted / visible.                   
                                                                    
  After the fix, step 3 yields an empty stack as expected.                             
                                                                                       
  ## Notes for reviewers                                                               
                                                                                       
  - Only `src/` was modified. `lib/` is regenerated by `yarn prepare` (`bob build`) at
  release time and is intentionally not in this diff.                                  
  - `yarn type`, `yarn lint`, and `yarn test` all pass.
  - No public API change; `modalfy().closeAllModals(callback)` still accepts and calls 
  the callback — it just fires synchronously now instead of after an animation.  