### PR TITLE
Remove use-memo-one dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
   },
   "dependencies": {
     "hoist-non-react-statics": "^3.3.2",
-    "react-is": "^17.0.2",
-    "use-memo-one": "^1.1.2"
+    "react-is": "^17.0.2"
   },
   "devDependencies": {
     "@colorfy-software/eslint-config": "^0.4.0",
@@ -61,6 +60,7 @@
     "@types/react": "^17.0.3",
     "@types/react-is": "^17.0.3",
     "@types/react-native": "0.66.15",
+    "@types/react-test-renderer": "17.0.1",
     "commitlint": "^11.0.0",
     "eslint": ">=8 <9",
     "husky": "^7.0.0",
@@ -71,6 +71,7 @@
     "react-native": "0.66.4",
     "react-native-builder-bob": "^0.18.2",
     "react-native-gesture-handler": "^2.24.0",
+    "react-test-renderer": "17.0.2",
     "release-it": "^14.2.2",
     "typescript": "^4.5.4"
   },

--- a/src/__tests__/useMemoOne.test.tsx
+++ b/src/__tests__/useMemoOne.test.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from 'react'
+import TestRenderer, { act } from 'react-test-renderer'
+
+import { useCallbackOne, useMemoOne } from '../lib/useMemoOne'
+
+describe('useMemoOne', () => {
+  it('keeps the same memoized value while inputs are equal', () => {
+    const values: unknown[] = []
+
+    const Component = ({ value }: { value: string }) => {
+      const memoized = useMemoOne(() => ({ value }), [value])
+
+      values.push(memoized)
+
+      return null
+    }
+
+    const renderer = TestRenderer.create(<Component value="first" />)
+
+    renderer.update(<Component value="first" />)
+    renderer.update(<Component value="second" />)
+
+    expect(values[0]).toBe(values[1])
+    expect(values[1]).not.toBe(values[2])
+  })
+
+  it('keeps the same callback while inputs are equal', () => {
+    const callbacks: unknown[] = []
+
+    const Component = ({ value }: { value: string }) => {
+      const callback = useCallbackOne(() => value, [value])
+
+      callbacks.push(callback)
+
+      return null
+    }
+
+    const renderer = TestRenderer.create(<Component value="first" />)
+
+    renderer.update(<Component value="first" />)
+    renderer.update(<Component value="second" />)
+
+    expect(callbacks[0]).toBe(callbacks[1])
+    expect(callbacks[1]).not.toBe(callbacks[2])
+  })
+
+  it('recomputes without inputs after the first committed render', () => {
+    const values: unknown[] = []
+
+    const Component = () => {
+      const [count, setCount] = useState(0)
+      const memoized = useMemoOne(() => ({ count }))
+
+      values.push(memoized)
+
+      useEffect(() => {
+        if (count === 0) setCount(1)
+      }, [count])
+
+      return null
+    }
+
+    act(() => {
+      TestRenderer.create(<Component />)
+    })
+
+    expect(values[0]).not.toBe(values[1])
+  })
+})

--- a/src/__tests__/useMemoOne.test.tsx
+++ b/src/__tests__/useMemoOne.test.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import TestRenderer, { act } from 'react-test-renderer'
 
-import { useCallbackOne, useMemoOne } from '../lib/useMemoOne'
+import { useCallbackOne, useMemoOne } from '../utils/useMemoOne'
 
 describe('useMemoOne', () => {
   it('keeps the same memoized value while inputs are equal', () => {

--- a/src/lib/ModalProvider.tsx
+++ b/src/lib/ModalProvider.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from 'use-memo-one'
 import React, { ReactNode, useEffect, useRef, useState } from 'react'
 import { BackHandler, NativeEventSubscription, Platform } from 'react-native'
 
@@ -14,6 +13,7 @@ import type {
 import ModalStack from './ModalStack'
 import ModalState from './ModalState'
 import ModalContext from './ModalContext'
+import { useCallback } from './useMemoOne'
 
 import { invariant, validateListener } from '../utils'
 

--- a/src/lib/ModalProvider.tsx
+++ b/src/lib/ModalProvider.tsx
@@ -13,7 +13,7 @@ import type {
 import ModalStack from './ModalStack'
 import ModalState from './ModalState'
 import ModalContext from './ModalContext'
-import { useCallback } from './useMemoOne'
+import { useCallback } from '../utils/useMemoOne'
 
 import { invariant, validateListener } from '../utils'
 

--- a/src/lib/ModalStack.tsx
+++ b/src/lib/ModalStack.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react'
-import { useCallback, useMemo } from 'use-memo-one'
 import { Easing, Animated, StyleSheet, TouchableWithoutFeedback, Platform } from 'react-native'
 
 import type {
@@ -13,6 +12,7 @@ import type {
 } from '../types'
 
 import StackItem from './StackItem'
+import { useCallback, useMemo } from './useMemoOne'
 
 import { absoluteFillStyle, computeUpdatedModalOptions, defaultOptions, getStackItemOptions, queueMacroTask, sh } from '../utils'
 

--- a/src/lib/ModalStack.tsx
+++ b/src/lib/ModalStack.tsx
@@ -12,7 +12,7 @@ import type {
 } from '../types'
 
 import StackItem from './StackItem'
-import { useCallback, useMemo } from './useMemoOne'
+import { useCallback, useMemo } from '../utils/useMemoOne'
 
 import { absoluteFillStyle, computeUpdatedModalOptions, defaultOptions, getStackItemOptions, queueMacroTask, sh } from '../utils'
 

--- a/src/lib/StackItem.tsx
+++ b/src/lib/StackItem.tsx
@@ -22,7 +22,7 @@ import type {
   ModalStackSavedStackItemsOptions,
 } from '../types'
 
-import { useMemo, useCallback } from './useMemoOne'
+import { useMemo, useCallback } from '../utils/useMemoOne'
 
 import {
   vh,

--- a/src/lib/StackItem.tsx
+++ b/src/lib/StackItem.tsx
@@ -5,7 +5,6 @@ import {
   GestureStateChangeEvent,
   FlingGestureHandlerEventPayload,
 } from 'react-native-gesture-handler'
-import { useMemo, useCallback } from 'use-memo-one'
 import { Animated, StyleSheet, ViewProps, ViewStyle } from 'react-native'
 import React, { ReactNode, useEffect, useRef, memo, useState } from 'react'
 
@@ -22,6 +21,8 @@ import type {
   ModalOnAnimateEventCallback,
   ModalStackSavedStackItemsOptions,
 } from '../types'
+
+import { useMemo, useCallback } from './useMemoOne'
 
 import {
   vh,

--- a/src/lib/useMemoOne.ts
+++ b/src/lib/useMemoOne.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef, useState } from 'react'
+
+type Cache<T> = {
+  inputs?: readonly unknown[]
+  result: T
+}
+
+const areInputsEqual = (newInputs: readonly unknown[], lastInputs: readonly unknown[]) => {
+  if (newInputs.length !== lastInputs.length) return false
+
+  for (let i = 0; i < newInputs.length; i += 1) {
+    if (newInputs[i] !== lastInputs[i]) return false
+  }
+
+  return true
+}
+
+export function useMemoOne<T>(getResult: () => T, inputs?: readonly unknown[]): T {
+  const initial = useState<Cache<T>>(() => ({
+    inputs,
+    result: getResult(),
+  }))[0]
+
+  const isFirstRun = useRef(true)
+  const committed = useRef(initial)
+
+  const useCache =
+    isFirstRun.current ||
+    Boolean(inputs && committed.current.inputs && areInputsEqual(inputs, committed.current.inputs))
+
+  const cache = useCache
+    ? committed.current
+    : {
+        inputs,
+        result: getResult(),
+      }
+
+  useEffect(() => {
+    isFirstRun.current = false
+    committed.current = cache
+  }, [cache])
+
+  return cache.result
+}
+
+export function useCallbackOne<T extends (...args: any[]) => any>(callback: T, inputs?: readonly unknown[]): T {
+  return useMemoOne(() => callback, inputs)
+}
+
+export const useMemo = useMemoOne
+export const useCallback = useCallbackOne

--- a/src/lib/useModal.ts
+++ b/src/lib/useModal.ts
@@ -1,10 +1,10 @@
 import { useContext } from 'react'
-import { useCallbackOne, useMemoOne } from 'use-memo-one'
 
 import type { ModalfyParams, UsableModalProp } from '../types'
 
 import { modalfy } from './ModalState'
 import ModalContext from './ModalContext'
+import { useCallbackOne, useMemoOne } from './useMemoOne'
 
 /**
  * Hook that exposes Modalfy's API.

--- a/src/lib/useModal.ts
+++ b/src/lib/useModal.ts
@@ -4,7 +4,7 @@ import type { ModalfyParams, UsableModalProp } from '../types'
 
 import { modalfy } from './ModalState'
 import ModalContext from './ModalContext'
-import { useCallbackOne, useMemoOne } from './useMemoOne'
+import { useCallback, useMemo } from '../utils/useMemoOne'
 
 /**
  * Hook that exposes Modalfy's API.
@@ -16,15 +16,15 @@ import { useCallbackOne, useMemoOne } from './useMemoOne'
 export default function <P extends ModalfyParams>(): UsableModalProp<P> {
   const context = useContext(ModalContext) as UsableModalProp<P>
 
-  const closeAllModals: UsableModalProp<P>['closeAllModals'] = useCallbackOne(modalfy().closeAllModals, [])
+  const closeAllModals: UsableModalProp<P>['closeAllModals'] = useCallback(modalfy().closeAllModals, [])
 
-  const closeModals: UsableModalProp<P>['closeModals'] = useCallbackOne(modalfy().closeModals, [])
+  const closeModals: UsableModalProp<P>['closeModals'] = useCallback(modalfy().closeModals, [])
 
-  const closeModal: UsableModalProp<P>['closeModal'] = useCallbackOne(modalfy().closeModal, [])
+  const closeModal: UsableModalProp<P>['closeModal'] = useCallback(modalfy().closeModal, [])
 
-  const openModal: UsableModalProp<P>['openModal'] = useCallbackOne(modalfy().openModal, [])
+  const openModal: UsableModalProp<P>['openModal'] = useCallback(modalfy().openModal, [])
 
-  const output = useMemoOne(
+  const output = useMemo(
     () => ({
       /**
        * This function closes every open modal.

--- a/src/utils/useMemoOne.ts
+++ b/src/utils/useMemoOne.ts
@@ -28,6 +28,7 @@ export function useMemoOne<T>(getResult: () => T, inputs?: readonly unknown[]): 
     isFirstRun.current ||
     Boolean(inputs && committed.current.inputs && areInputsEqual(inputs, committed.current.inputs))
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const cache = useCache
     ? committed.current
     : {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2317,6 +2317,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-test-renderer@17.0.1":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz#3120f7d1c157fba9df0118dae20cb0297ee0e06b"
+  integrity sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@^17.0.3":
   version "17.0.38"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.38.tgz#f24249fefd89357d5fa71f739a686b8d7c7202bd"
@@ -8814,6 +8821,11 @@ react-devtools-core@^4.13.0:
     shell-quote "^1.6.1"
     ws "^7"
 
+"react-is@^16.12.0 || ^17.0.0 || ^18.0.0":
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
+
 react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -8910,6 +8922,24 @@ react-refresh@^0.4.0:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.4.3.tgz#966f1750c191672e76e16c2efa569150cc73ab53"
   integrity sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA==
+
+react-shallow-renderer@^16.13.1:
+  version "16.15.0"
+  resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz#48fb2cf9b23d23cde96708fe5273a7d3446f4457"
+  integrity sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==
+  dependencies:
+    object-assign "^4.1.1"
+    react-is "^16.12.0 || ^17.0.0 || ^18.0.0"
+
+react-test-renderer@17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-17.0.2.tgz#4cd4ae5ef1ad5670fc0ef776e8cc7e1231d9866c"
+  integrity sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==
+  dependencies:
+    object-assign "^4.1.1"
+    react-is "^17.0.2"
+    react-shallow-renderer "^16.13.1"
+    scheduler "^0.20.2"
 
 react@17.0.2:
   version "17.0.2"
@@ -10620,11 +10650,6 @@ url-parse@^1.5.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
-
-use-memo-one@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.2.tgz#0c8203a329f76e040047a35a1197defe342fab20"
-  integrity sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==
 
 use-subscription@^1.0.0:
   version "1.5.1"


### PR DESCRIPTION
This removes the use-memo-one runtime dependency, which still declares a React peer dependency range that stops at React 18 and causes warnings for React 19 consumers. Modalfy still needs stable memoized values and callbacks, so this keeps that behavior without depending on the stale package.

The existing Modalfy imports now point to a small internal stable memo helper, and use-memo-one has been removed from package dependencies.