### PR TITLE
Replace removed absoluteFillObject usage

### DIFF
--- a/src/lib/ModalStack.tsx
+++ b/src/lib/ModalStack.tsx
@@ -14,7 +14,7 @@ import type {
 
 import StackItem from './StackItem'
 
-import { computeUpdatedModalOptions, defaultOptions, getStackItemOptions, queueMacroTask, sh } from '../utils'
+import { absoluteFillStyle, computeUpdatedModalOptions, defaultOptions, getStackItemOptions, queueMacroTask, sh } from '../utils'
 
 type Props<P extends ModalfyParams> = SharedProps<P>
 
@@ -206,17 +206,17 @@ const styles = StyleSheet.create({
   container: {
     ...Platform.select({
       android: {
-        ...StyleSheet.absoluteFillObject,
+        ...absoluteFillStyle,
         zIndex: 0,
       },
       ios: {
-        ...StyleSheet.absoluteFillObject,
+        ...absoluteFillStyle,
         zIndex: 0,
       },
     }),
   },
   containerWeb: {
-    ...StyleSheet.absoluteFillObject,
+    ...absoluteFillStyle,
     overflow: 'hidden',
     height: '100vh',
     width: '100vw',
@@ -226,7 +226,7 @@ const styles = StyleSheet.create({
     maxWidth: '-webkit-fill-available',
   },
   backdrop: {
-    ...StyleSheet.absoluteFillObject,
+    ...absoluteFillStyle,
   },
 })
 

--- a/src/lib/StackItem.tsx
+++ b/src/lib/StackItem.tsx
@@ -23,7 +23,14 @@ import type {
   ModalStackSavedStackItemsOptions,
 } from '../types'
 
-import { computeUpdatedModalOptions, queueMacroTask, getStackItemOptions, validateStackItemOptions, vh } from '../utils'
+import {
+  absoluteFillStyle,
+  computeUpdatedModalOptions,
+  queueMacroTask,
+  getStackItemOptions,
+  validateStackItemOptions,
+  vh,
+} from '../utils'
 
 type Props<P extends ModalfyParams> = SharedProps<P> & {
   zIndex: number
@@ -399,7 +406,7 @@ ${stackItem.name}: {
 
 const styles = StyleSheet.create({
   container: {
-    ...StyleSheet.absoluteFillObject,
+    ...absoluteFillStyle,
     alignItems: 'center',
     backgroundColor: 'transparent',
   },

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 import { Dimensions, Easing } from 'react-native'
+import type { ViewStyle } from 'react-native'
 
 import type { ModalOptions, ModalStackItemOptions, ModalStackOptions } from '../types'
 
@@ -7,6 +8,14 @@ export const vw = (percentage: number) => (Dimensions.get('window').width * perc
 export const vh = (percentage: number) => (Dimensions.get('window').height * percentage) / 100
 
 export const sh = (percentage: number) => (Dimensions.get('screen').height * percentage) / 100
+
+export const absoluteFillStyle: ViewStyle = {
+  position: 'absolute',
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+}
 
 export const defaultOptions: ModalOptions = {
   animateInConfig: {


### PR DESCRIPTION
React Native 0.85 removed StyleSheet.absoluteFillObject, which can cause Modalfy's absolute overlay styles to be dropped. This replaces those usages with an internal plain-object absolute fill style so the same layout values are applied across React Native versions.

The change avoids using StyleSheet.absoluteFill directly because older React Native typings treat it as a registered style rather than a spreadable object.